### PR TITLE
Updating column header from 'report_count' to 'count'

### DIFF
--- a/src/main/scala/io/opentargets/openfda/stage/MonteCarloSampling.scala
+++ b/src/main/scala/io/opentargets/openfda/stage/MonteCarloSampling.scala
@@ -42,7 +42,7 @@ object MonteCarloSampling {
     val exprs = List(
       "chembl_id",
       "reaction_reactionmeddrapt as event",
-      "A as report_count",
+      "A as count",
       "llr",
       "critVal_drug as critval"
     )


### PR DESCRIPTION
Fixing bug where output column has the wrong name. 