### PR TITLE
Making inclusion of meddra terms optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Specify the number of permutations and the relevance percentile threshhold.
 
 Paths to the blacklisted_events, chembl data and fda database dump. 
 
-#### Meddra inputs
+#### Meddra inputs (Optional)
 
-Path to Meddra data release. 
+Path to Meddra data release if available. Remove key from configuration file if data is not available.  
 
 #### Outputs
 
@@ -201,7 +201,7 @@ The fat jar can be executed on a local installation of Spark using `spark-submit
 
 The following sections outline how to obtain the necessary input files for the `platformDataProcessFDA.sc ` script.
 
-### Generate the indices dump from ES7
+#### Generate the indices dump from ES7
 
 You will need to either connect to a machine containing the ES or forward the ssh port from it
 ```sh
@@ -238,7 +238,14 @@ exit 0
 
 #### Blacklist
 
-The blacklist is a manually curated txt file to exclude events that are uninformative for our purposes. This is passed as a parameter to the `platformDataProcessFDA.sc` script. 
+The blacklist is a manually curated txt file to exclude events that are uninformative for our purposes. This is passed 
+as a parameter to the `platformDataProcessFDA.sc` script. 
+
+#### Meddra
+
+This pipeline uses an _optional_ subset of data from the [Medical Dictionary for Regulatory Activities](https://www.meddra.org) to link the adverse event terms used by the FDA back to their standardised names. 
+
+This data is included in the pipeline output provided by Open Targets, but if you are running the pipeline locally you need to download the most recent Meddra release which is subject to licensing restrictions. 
 
 ### Outputs
 
@@ -273,6 +280,8 @@ The sampled dataset is saved to disk, and can be used as an input for subsequent
 | 1.0.0 | June 2020 | Initial release | 
 | 1.0.1 | September 2020 | Fixing output names; headers for CSV, keys for JSON | 
 | 1.1.0 | October 2020 | Adding meddra preferred terms to output. | 
+| 1.1.1 | November 2020 | Making Meddra term inclusion optional. | 
+
 
 # Copyright
 Copyright 2014-2018 Biogen, Celgene Corporation, EMBL - European Bioinformatics Institute, GlaxoSmithKline, Takeda Pharmaceutical Company and Wellcome Sanger Institute

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
       scalaVersion := "2.12.10",
     )),
     name := "openfda",
-    version := "1.1.0",
+    version := "1.1.1",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled"),
     scalacOptions ++= Seq("-deprecation", "-unchecked"),

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -28,6 +28,6 @@ fda {
     blacklist = ${?inputPath}"blacklisted_events.txt"
     chembl-data = ${?inputPath}"*_drug-data.json"
     fda-data = ${?inputPath}"sample/**/*.jsonl"
-    meddra-release = ${?inputPath}"meddra23.1/"
+  //  meddra-release = ${?inputPath}"meddra23.1/"
   }
 }

--- a/src/main/scala/io/opentargets/openfda/config/Configuration.scala
+++ b/src/main/scala/io/opentargets/openfda/config/Configuration.scala
@@ -11,7 +11,7 @@ case class FdaInputs(
     blacklist: String,
     chemblData: String,
     fdaData: String,
-    meddraRelease: String
+    meddraRelease: Option[String]
 ) {
   require(blacklist.endsWith("txt"), "Blacklist is required in txt extension")
   require(chemblData.endsWith("json"), "ChEMBL data is required in json format")

--- a/src/test/scala/io/opentargets/openfda/utils/ConfigurationTest.scala
+++ b/src/test/scala/io/opentargets/openfda/utils/ConfigurationTest.scala
@@ -17,7 +17,7 @@ class FdaConfigurationTest extends AnyFlatSpecLike with Matchers {
   "Fda config" should "not accept invalid output formats" in {
     a[IllegalArgumentException] should be thrownBy {
       Fda(MonteCarlo(1, .04),
-          FdaInputs(".txt", "json", "jsonl", "asc"),
+          FdaInputs(".txt", "json", "jsonl", Option("asc")),
           Seq("csv", "txt"),
           Sampling(""))
     }
@@ -26,7 +26,7 @@ class FdaConfigurationTest extends AnyFlatSpecLike with Matchers {
   "Fda config" should "accept output formats" in {
     val fdaConfig =
       Fda(MonteCarlo(1, .04),
-          FdaInputs(".txt", "json", "jsonl", "asc"),
+          FdaInputs(".txt", "json", "jsonl", None),
           Seq("csv", "json", "jsonl"),
           Sampling(""))
     assert(fdaConfig.outputs.length.equals(3))
@@ -57,16 +57,16 @@ class MonteCarloConfigTest extends TableDrivenPropertyChecks with Matchers with 
 class FdaInputsTest extends AnyFlatSpecLike with TableDrivenPropertyChecks with Matchers {
   private val fdaInputInvalidCombos =
     Table(
-      ("blist", "chembl", "fda", "asc"),
-      ("txt", "json", "json", "asc"),
-      ("txt", "json", "csv", "asbc"),
-      ("txt", "json", "html", "asc"),
-      ("txt", "csv", "jsonl", "asc"),
-      ("txt", "txt", "jsonl", "asc"),
-      ("txt", "md", "jsonl", "asd"),
-      ("csv", "json", "jsonl", "asc"),
-      ("json", "json", "jsonl", "asc"),
-      ("html", "json", "jsonl", "asc")
+      ("blist", "chembl", "fda", "meddra"),
+      ("txt", "json", "json", Option("asc")),
+      ("txt", "json", "csv", Option("asbc")),
+      ("txt", "json", "html", Option("asc")),
+      ("txt", "csv", "jsonl", Option("asc")),
+      ("txt", "txt", "jsonl", Option("asc")),
+      ("txt", "md", "jsonl", Option("asd")),
+      ("csv", "json", "jsonl", Option("asc")),
+      ("json", "json", "jsonl", Option("asc")),
+      ("html", "json", "jsonl", Option("asc"))
     )
   "Fda config" should "not accept invalid output formats" in {
     forAll(fdaInputInvalidCombos) { (blist: String, chembl: String, fda: String, meddra) =>


### PR DESCRIPTION
Since the Meddra data is not widely available publicly, the pipeline should support users who do not have access to the data.