### PR TITLE
Add parquet to the type of output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
       scalaVersion := "2.12.10",
     )),
     name := "openfda",
-    version := "1.1.1",
+    version := "1.1.2",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled"),
     scalacOptions ++= Seq("-deprecation", "-unchecked"),

--- a/src/main/scala/io/opentargets/openfda/ETL.scala
+++ b/src/main/scala/io/opentargets/openfda/ETL.scala
@@ -29,7 +29,11 @@ object ETL extends LazyLogging {
         // write results if necessary
         logger.info("Writing results of FDA pipeline...")
 
-        Writers.writeFdaResults(openFdaDataAggByChembl, context.configuration.common.output)
+        if (fdaConfig.outputs.nonEmpty) {
+          fdaConfig.outputs.foreach { extension =>
+            Writers.writeFdaResults(openFdaDataAggByChembl, context.configuration.common.output, extension)
+          }
+        }
 
         if (fdaConfig.outputs.nonEmpty) {
           fdaConfig.outputs.foreach { extension =>

--- a/src/main/scala/io/opentargets/openfda/config/Configuration.scala
+++ b/src/main/scala/io/opentargets/openfda/config/Configuration.scala
@@ -28,7 +28,7 @@ case class Fda(montecarlo: MonteCarlo,
                fdaInputs: FdaInputs,
                outputs: Seq[String],
                sampling: Sampling) {
-  private def validOutput(str: String): Boolean = List("csv", "json", "jsonl").contains(str)
+  private def validOutput(str: String): Boolean = List("csv", "json", "jsonl","parquet").contains(str)
   require(outputs.forall(validOutput))
 }
 object Configuration extends LazyLogging {

--- a/src/main/scala/io/opentargets/openfda/utils/Writers.scala
+++ b/src/main/scala/io/opentargets/openfda/utils/Writers.scala
@@ -24,14 +24,30 @@ object Writers extends LazyLogging {
         logger.info("Writing monte carlo results as json output...")
         results.write
           .json(s"$outputPath/agg_critval_drug/")
+      case "parquet" =>
+        logger.info("Writing monte carlo results as parquet output...")
+        results.write
+          .format("parquet")
+          .save(s"$outputPath/agg_critval_drug-parquet/")
 
       case err: String => logger.error(s"Unrecognised output format $err")
     }
 
   }
 
-  def writeFdaResults(results: DataFrame, outputPath: String): Unit = {
-    logger.info("Writing results of fda data transformation aggregated by Chembl...")
-    results.write.json(s"$outputPath/agg_by_chembl/")
+  def writeFdaResults(results: DataFrame, outputPath: String, extension: String): Unit = {
+    logger.info("Writing results of fda data transformation aggregated by Chembl.")
+    extension match {
+      case "json" =>
+        logger.info("format json")
+        results.write.
+           format(extension).save(s"$outputPath/agg_by_chembl/")
+      case "parquet" =>
+        logger.info("format paquet")
+        results.write.
+          format(extension).save(s"$outputPath/agg_by_chembl_$extension/")
+
+      case err: String => logger.error(s"Unrecognised output format $err")
+    }
   }
 }

--- a/src/test/scala/io/opentargets/openfda/utils/ConfigurationTest.scala
+++ b/src/test/scala/io/opentargets/openfda/utils/ConfigurationTest.scala
@@ -27,7 +27,7 @@ class FdaConfigurationTest extends AnyFlatSpecLike with Matchers {
     val fdaConfig =
       Fda(MonteCarlo(1, .04),
           FdaInputs(".txt", "json", "jsonl", None),
-          Seq("csv", "json", "jsonl"),
+          Seq("csv", "json", "parquet"),
           Sampling(""))
     assert(fdaConfig.outputs.length.equals(3))
   }


### PR DESCRIPTION
Added the option "parquet" to the output.
The new output could be
outputs: [
"json",
"parquet",
"csv"
]

I just transformed the code. It would be better to refactor the input/output as ETL repository.
New version 1.1.2

I will tag the release