### PR TITLE
naming refactor

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,8 +1,8 @@
 spark-uri = null
 inputPath = "gs://ot-snapshots/jarrod/fdaTestIn/"
 common {
-
-  output = "gs://ot-snapshots/jarrod/fdaTestOut"
+  output = "gs://ot-snapshots/etl/latest/adverseDrugReaction"
+  output = ${?OT_ETL_OUTPUT}
   default-steps = [
     "fda"
   ]
@@ -14,16 +14,16 @@ fda {
   }
   sampling {
     size = 0.1
-    output = ${?common.output}"/sample"
+    output = ${?common.output}"Sample"
     enabled = false
   }
   // can be "csv" or "json"
   // csv will be very slow as it gathers all the data onto a single
   // spark partition before writing.
   outputs = [
-    "json"
-//    "csv"
-//    "parquet"
+    "parquet"
+    //    "json"
+    //    "csv"
   ]
   fda-inputs {
     blacklist = ${?inputPath}"blacklisted_events.txt"

--- a/src/main/scala/io/opentargets/openfda/utils/Writers.scala
+++ b/src/main/scala/io/opentargets/openfda/utils/Writers.scala
@@ -18,17 +18,17 @@ object Writers extends LazyLogging {
           .write
           .option("compression", "gzip")
           .option("header", "true")
-          .csv(s"$outputPath/agg_critval_drug_csv/")
+          .csv(s"$outputPath")
 
       case "json" =>
         logger.info("Writing monte carlo results as json output...")
         results.write
-          .json(s"$outputPath/agg_critval_drug/")
+          .json(s"$outputPath")
       case "parquet" =>
         logger.info("Writing monte carlo results as parquet output...")
         results.write
           .format("parquet")
-          .save(s"$outputPath/agg_critval_drug-parquet/")
+          .save(s"$outputPath")
 
       case err: String => logger.error(s"Unrecognised output format $err")
     }
@@ -41,11 +41,11 @@ object Writers extends LazyLogging {
       case "json" =>
         logger.info("format json")
         results.write.
-           format(extension).save(s"$outputPath/agg_by_chembl/")
+           format(extension).save(s"${outputPath}Unfiltered")
       case "parquet" =>
         logger.info("format paquet")
         results.write.
-          format(extension).save(s"$outputPath/agg_by_chembl_$extension/")
+          format(extension).save(s"${outputPath}Unfiltered")
 
       case err: String => logger.error(s"Unrecognised output format $err")
     }


### PR DESCRIPTION
@JarrodBaker, after meeting with @d0choa and trying to meet naming conventions we agreed on changing OpenFDA namings. I also made the same output whether you have parquet or JSON because the ultimate aim of this is integrating this with ETL. so multi-format at the same time is something we are not currently supporting and I think is out of the scope of the ETL